### PR TITLE
feat: Added more target roles for job descriptions

### DIFF
--- a/backend/src/mocks/job-descriptions/ai-researcher.ts
+++ b/backend/src/mocks/job-descriptions/ai-researcher.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const aiResearcherJobDescriptions: JobDescription[] = [
+	{
+		title: "AI Researcher",
+		description: "Explore cutting-edge artificial intelligence methods and develop novel AI algorithms.",
+		responsibilities: [
+			"Conduct research in deep learning, reinforcement learning, and NLP",
+			"Publish findings in academic and industry journals",
+			"Experiment with large-scale datasets and models",
+			"Collaborate with universities and research labs",
+			"Develop prototypes for new AI applications",
+			"Stay updated with the latest AI breakthroughs",
+			"Mentor junior researchers and interns"
+		],
+		qualifications: [
+			"PhD or Master's degree in Computer Science, AI, or related field",
+			"Experience with Python, TensorFlow/PyTorch",
+			"Strong mathematics background (linear algebra, probability, optimization)",
+			"Research methodology and publication record",
+			"Excellent analytical and communication skills"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/civil-engineer.ts
+++ b/backend/src/mocks/job-descriptions/civil-engineer.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const civilEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Civil Engineer",
+		description: "Design and supervision of infrastructure projects, including roads, bridges, and buildings. Ensure compliance with safety standards and collaborate with architects and contractors.",
+		responsibilities: [
+			"Design and analyze structural components and systems",
+			"Prepare technical drawings, plans, and specifications",
+			"Perform site inspections and ensure compliance with safety standards",
+			"Conduct feasibility studies and cost estimates",
+			"Collaborate with architects, contractors, and government agencies",
+			"Supervise construction and maintenance of infrastructure",
+			"Apply sustainable and environmentally friendly practices"
+		],
+		qualifications: [
+			"Bachelor's degree in Civil Engineering or related field",
+			"Experience with AutoCAD/Civil 3D",
+			"Knowledge of project management and structural analysis",
+			"Familiarity with surveying and construction regulations",
+			"Strong teamwork and communication skills"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/cloud-architect.ts
+++ b/backend/src/mocks/job-descriptions/cloud-architect.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const cloudArchitectJobDescriptions: JobDescription[] = [
+	{
+		title: "Cloud Architect",
+		description: "Design scalable and secure cloud solutions, manage cloud infrastructure, and lead cloud adoption strategies.",
+		responsibilities: [
+			"Develop cloud architecture blueprints and strategies",
+			"Design secure, scalable, and cost-efficient solutions",
+			"Migrate on-premise systems to the cloud",
+			"Ensure compliance with security and governance standards",
+			"Collaborate with development and DevOps teams",
+			"Evaluate emerging cloud technologies",
+			"Provide technical leadership on cloud adoption"
+		],
+		qualifications: [
+			"Bachelor's degree in Computer Science or related field",
+			"Experience with AWS/Azure/GCP architecture",
+			"Knowledge of networking, security, and Kubernetes",
+			"Familiarity with Terraform and cost optimization",
+			"Strong stakeholder communication skills"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/cybersecurity-analyst.ts
+++ b/backend/src/mocks/job-descriptions/cybersecurity-analyst.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const cybersecurityAnalystJobDescriptions: JobDescription[] = [
+	{
+		title: "Cybersecurity Analyst",
+		description: "Protect systems and networks from cyber threats, monitor IT systems, and respond to security incidents.",
+		responsibilities: [
+			"Monitor network traffic for suspicious activity",
+			"Conduct vulnerability assessments and penetration tests",
+			"Implement security protocols and firewalls",
+			"Respond to security incidents and breaches",
+			"Ensure compliance with security policies and regulations",
+			"Train staff on security best practices",
+			"Keep up-to-date with evolving threats"
+		],
+		qualifications: [
+			"Bachelor's degree in Cybersecurity, Computer Science, or related field",
+			"Experience with network security and firewalls",
+			"Knowledge of SIEM tools and incident response",
+			"Familiarity with Python/Shell scripting",
+			"Understanding of security frameworks (NIST, ISO)"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/electrical-engineer.ts
+++ b/backend/src/mocks/job-descriptions/electrical-engineer.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const electricalEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Electrical Engineer",
+		description: "Design and maintain electrical systems, including power distribution, lighting, and control systems.",
+		responsibilities: [
+			"Design power distribution, lighting, and control systems",
+			"Develop electrical schematics and circuit layouts",
+			"Perform calculations for load, efficiency, and safety",
+			"Conduct inspections and troubleshoot electrical issues",
+			"Ensure compliance with electrical codes and standards",
+			"Oversee installation and commissioning of systems",
+			"Collaborate on automation and renewable energy projects"
+		],
+		qualifications: [
+			"Bachelor's degree in Electrical Engineering or related field",
+			"Experience with circuit design and AutoCAD Electrical",
+			"Knowledge of PLCs and MATLAB/Simulink",
+			"Familiarity with renewable energy systems",
+			"Understanding of safety standards (IEC/IEEE)"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/firmware-engineer.ts
+++ b/backend/src/mocks/job-descriptions/firmware-engineer.ts
@@ -1,0 +1,22 @@
+import { JobDescription } from "../../types/mocks";
+
+export const firmwareEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Firmware Engineer",
+		description: "Develop and maintain embedded firmware for electronic devices and systems.",
+		responsibilities: [
+			"Design, develop, and test embedded firmware",
+			"Collaborate with hardware and software teams",
+			"Debug and optimize firmware for performance",
+			"Document firmware architecture and code",
+			"Support manufacturing and field deployment"
+		],
+		qualifications: [
+			"Bachelor's degree in Electrical Engineering, Computer Engineering, or related field",
+			"Experience with C/C++ for embedded systems",
+			"Knowledge of microcontrollers and communication protocols",
+			"Familiarity with hardware debugging tools",
+			"Strong problem-solving skills"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/index.ts
+++ b/backend/src/mocks/job-descriptions/index.ts
@@ -4,40 +4,109 @@ import { javaJobDescriptions } from "./java-developer";
 import { businessAnalystJobDescriptions } from "./business-analyst";
 import { dataAnalystJobDescriptions } from "./data-analyst";
 
-export type JobDescriptionCategory = "intern" | "java-developer" | "business-analyst" | "data-analyst" | "custom";
+export type JobDescriptionCategory =
+  | "custom"
+  | "intern"
+  | "software-engineer"
+  | "java-developer"
+  | "business-analyst"
+  | "data-analyst"
+  | "civil-engineer"
+  | "mechatronics-engineer"
+  | "cybersecurity-analyst"
+  | "ml-engineer"
+  | "cloud-architect"
+  | "structural-engineer"
+  | "electrical-engineer"
+  | "ai-researcher"
+  | "firmware-engineer";
 
-type PredefinedJobDescriptionCategory = Exclude<JobDescriptionCategory, "custom">;
+type PredefinedJobDescriptionCategory = Exclude<
+  JobDescriptionCategory,
+  "custom"
+>;
 
-export const jobDescriptionCategories: Record<PredefinedJobDescriptionCategory, { label: string; descriptions: JobDescription[] }> = {
-  "intern": {
-    label: "Software Engineering Intern",
-    descriptions: internJobDescriptions
+const jobDescriptionCategories: Record<
+  PredefinedJobDescriptionCategory,
+  { label: string; descriptions: JobDescription[] }
+> = {
+  intern: {
+    label: "Intern/Entry Level",
+    descriptions: internJobDescriptions,
+  },
+  "software-engineer": {
+    label: "Full-Stack Software Engineer",
+    descriptions: [],
   },
   "java-developer": {
     label: "Java Developer",
-    descriptions: javaJobDescriptions
+    descriptions: javaJobDescriptions,
   },
   "business-analyst": {
-    label: "Business Analyst", 
-    descriptions: businessAnalystJobDescriptions
+    label: "Business Analyst",
+    descriptions: businessAnalystJobDescriptions,
   },
   "data-analyst": {
     label: "Data Analyst",
-    descriptions: dataAnalystJobDescriptions
-  }
+    descriptions: dataAnalystJobDescriptions,
+  },
+  "civil-engineer": {
+    label: "Civil Engineer",
+    descriptions: [],
+  },
+  "mechatronics-engineer": {
+    label: "Mechatronics Engineer",
+    descriptions: [],
+  },
+  "cybersecurity-analyst": {
+    label: "Cybersecurity Analyst",
+    descriptions: [],
+  },
+  "ml-engineer": {
+    label: "Machine Learning Engineer",
+    descriptions: [],
+  },
+  "cloud-architect": {
+    label: "Cloud Architect",
+    descriptions: [],
+  },
+  "structural-engineer": {
+    label: "Structural Engineer",
+    descriptions: [],
+  },
+  "electrical-engineer": {
+    label: "Electrical Engineer",
+    descriptions: [],
+  },
+  "ai-researcher": {
+    label: "AI Researcher",
+    descriptions: [],
+  },
+  "firmware-engineer": {
+    label: "Firmware Engineer",
+    descriptions: [],
+  },
 };
 
-export const getJobDescriptionByCategory = (category: JobDescriptionCategory): JobDescription => {
+export const getJobDescriptionByCategory = (
+  category: JobDescriptionCategory
+): JobDescription => {
   if (category === "custom") {
     // Return a placeholder - this should be handled by the caller
     return {
       title: "Custom Position",
       description: "Custom job description",
       responsibilities: [],
-      qualifications: []
+      qualifications: [],
     };
   }
-  return jobDescriptionCategories[category as PredefinedJobDescriptionCategory].descriptions[0];
+  return jobDescriptionCategories[category as PredefinedJobDescriptionCategory]
+    .descriptions[0];
 };
 
-export { internJobDescriptions, javaJobDescriptions, businessAnalystJobDescriptions, dataAnalystJobDescriptions };
+export {
+  internJobDescriptions,
+  javaJobDescriptions,
+  businessAnalystJobDescriptions,
+  dataAnalystJobDescriptions,
+};

--- a/backend/src/mocks/job-descriptions/mechatronics-engineer.ts
+++ b/backend/src/mocks/job-descriptions/mechatronics-engineer.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const mechatronicsEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Mechatronics Engineer",
+		description: "Integration of mechanical, electrical, and software systems for automation and robotics projects.",
+		responsibilities: [
+			"Design electro-mechanical systems and prototypes",
+			"Develop embedded software for control systems",
+			"Integrate sensors, actuators, and microcontrollers",
+			"Test and calibrate robotic systems",
+			"Conduct simulations and performance analysis",
+			"Work with interdisciplinary teams on automation projects",
+			"Apply control theory and system dynamics"
+		],
+		qualifications: [
+			"Bachelor's degree in Mechatronics, Mechanical, or Electrical Engineering",
+			"Experience with CAD software and embedded C/C++",
+			"Knowledge of Python/Matlab and PLC programming",
+			"Familiarity with robotics and electronics",
+			"Strong systems integration skills"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/ml-engineer.ts
+++ b/backend/src/mocks/job-descriptions/ml-engineer.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const mlEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Machine Learning Engineer",
+		description: "Build and deploy AI/ML models into production, optimize model performance, and collaborate with data scientists.",
+		responsibilities: [
+			"Design, train, and fine-tune machine learning models",
+			"Implement data preprocessing and feature engineering pipelines",
+			"Deploy ML models into production environments",
+			"Optimize models for performance and scalability",
+			"Collaborate with data scientists and software engineers",
+			"Monitor models for drift and retraining as needed",
+			"Document methodologies and results"
+		],
+		qualifications: [
+			"Bachelor's degree in Computer Science, Data Science, or related field",
+			"Experience with Python, TensorFlow/PyTorch, scikit-learn",
+			"Knowledge of SQL and cloud platforms (AWS/GCP/Azure)",
+			"Familiarity with MLOps practices",
+			"Strong data structures and algorithms skills"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/software-engineer.ts
+++ b/backend/src/mocks/job-descriptions/software-engineer.ts
@@ -1,0 +1,27 @@
+import { JobDescription } from "../../types/mocks";
+
+export const softwareEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Full-Stack Software Engineer",
+		description: "Design, develop, and maintain web applications using modern front-end and back-end technologies. Collaborate with cross-functional teams to deliver scalable and high-quality software solutions.",
+		responsibilities: [
+			"Develop and maintain web applications using JavaScript/TypeScript, React, and Node.js",
+			"Design RESTful APIs and integrate with databases (SQL/NoSQL)",
+			"Write clean, efficient, and well-documented code",
+			"Participate in code reviews and provide constructive feedback",
+			"Troubleshoot and debug issues across the stack",
+			"Collaborate with designers, product managers, and other engineers",
+			"Implement automated tests and ensure software quality",
+			"Stay updated with emerging technologies and best practices"
+		],
+		qualifications: [
+			"Bachelor's degree in Computer Science or related field",
+			"2+ years of experience in full-stack development",
+			"Proficiency with JavaScript/TypeScript, React, and Node.js",
+			"Experience with RESTful APIs and database design",
+			"Familiarity with Git and Agile methodologies",
+			"Strong problem-solving and communication skills",
+			"Experience with cloud platforms (AWS, Azure, GCP) is a plus"
+		]
+	}
+];

--- a/backend/src/mocks/job-descriptions/structural-engineer.ts
+++ b/backend/src/mocks/job-descriptions/structural-engineer.ts
@@ -1,0 +1,24 @@
+import { JobDescription } from "../../types/mocks";
+
+export const structuralEngineerJobDescriptions: JobDescription[] = [
+	{
+		title: "Structural Engineer",
+		description: "Design and analysis of safe, durable structures, ensuring compliance with building codes and safety regulations.",
+		responsibilities: [
+			"Design structural frameworks and components",
+			"Perform load calculations and finite element analysis",
+			"Prepare drawings, technical specifications, and reports",
+			"Conduct site visits and inspections",
+			"Ensure compliance with building codes and safety regulations",
+			"Collaborate with architects and construction teams",
+			"Incorporate sustainability into structural design"
+		],
+		qualifications: [
+			"Bachelor's degree in Structural Engineering or related field",
+			"Experience with AutoCAD/Revit, SAP2000/ETABS",
+			"Knowledge of finite element analysis and construction materials",
+			"Project management skills",
+			"Strong teamwork and communication skills"
+		]
+	}
+];

--- a/frontend/src/components/InterviewAnalyser.tsx
+++ b/frontend/src/components/InterviewAnalyser.tsx
@@ -16,7 +16,7 @@ import TargetRole from './TargetRole';
 import { Alert, AlertTitle, AlertDescription } from './ui/alert';
 
 export function InterviewAnalyser() {
-  const [selectedJobDescription, setSelectedJobDescription] = useState<JobDescriptionCategory>('java-developer');
+  const [selectedJobDescription, setSelectedJobDescription] = useState<JobDescriptionCategory>('intern');
   const [customJobDescription, setCustomJobDescription] = useState<string | undefined>(undefined);
 
   const [question, setQuestion] = useState<Question | null>(null);

--- a/frontend/src/types/jobDescriptions.ts
+++ b/frontend/src/types/jobDescriptions.ts
@@ -1,9 +1,19 @@
 export type JobDescriptionCategory =
+  | "custom"
   | "intern"
+  | "software-engineer"
   | "java-developer"
   | "business-analyst"
   | "data-analyst"
-  | "custom";
+  | "civil-engineer"
+  | "mechatronics-engineer"
+  | "cybersecurity-analyst"
+  | "ml-engineer"
+  | "cloud-architect"
+  | "structural-engineer"
+  | "electrical-engineer"
+  | "ai-researcher"
+  | "firmware-engineer";
 
 interface JobDescriptionOption {
   value: JobDescriptionCategory;
@@ -13,6 +23,37 @@ interface JobDescriptionOption {
 }
 
 export const jobDescriptionOptions: JobDescriptionOption[] = [
+  {
+    value: "intern",
+    label: "Intern/Entry Level",
+    description: "General entry-level position for new graduates",
+    fullDescription: `An Intern or Entry-level position is designed for recent graduates or career changers. Key expectations include:
+
+    • Learning fundamental programming and business concepts
+    • Contributing to team projects under supervision
+    • Developing problem-solving and analytical skills
+    • Participating in code reviews and team meetings
+    • Following established processes and best practices
+    • Showing eagerness to learn and grow
+    • Building professional communication skills
+
+  Focus areas: Basic programming, teamwork, communication, adaptability, willingness to learn.`,
+  },
+  {
+    value: "software-engineer",
+    label: "Full-Stack Software Engineer",
+    description: "Full-stack development with modern web technologies",
+    fullDescription: `A Full-Stack Software Engineer designs, develops, and maintains software applications. Key responsibilities include:
+    • Writing clean, efficient, and maintainable code
+    • Collaborating with cross-functional teams to define and implement features
+    • Participating in code reviews and providing constructive feedback
+    • Troubleshooting and debugging issues in a timely manner
+    • Staying updated with emerging technologies and industry trends
+    • Ensuring software quality through testing and documentation
+    • Contributing to continuous improvement of development processes
+
+  Required skills: RESTful APIs, Git, Agile methodologies, cloud services, front-end frameworks, back-end development, SQL/NoSQL databases`,
+  },
   {
     value: "java-developer",
     label: "Java Developer",
@@ -62,19 +103,145 @@ export const jobDescriptionOptions: JobDescriptionOption[] = [
   Required skills: SQL, Excel, Python/R, Tableau/Power BI, statistics, data visualization, critical thinking.`,
   },
   {
-    value: "intern",
-    label: "Intern/Entry Level",
-    description: "General entry-level position for new graduates",
-    fullDescription: `An Intern or Entry-level position is designed for recent graduates or career changers. Key expectations include:
+    value: "civil-engineer",
+    label: "Civil Engineer",
+    description: "Design and supervision of infrastructure projects",
+    fullDescription: `A Civil Engineer is responsible for planning and overseeing construction projects. Key responsibilities include:
 
-    • Learning fundamental programming and business concepts
-    • Contributing to team projects under supervision
-    • Developing problem-solving and analytical skills
-    • Participating in code reviews and team meetings
-    • Following established processes and best practices
-    • Showing eagerness to learn and grow
-    • Building professional communication skills
+    • Designing and analyzing structural components and systems
+    • Preparing technical drawings, plans, and specifications
+    • Performing site inspections and ensuring compliance with safety standards
+    • Conducting feasibility studies and cost estimates
+    • Collaborating with architects, contractors, and government agencies
+    • Supervising construction and maintenance of roads, bridges, and buildings
+    • Applying sustainable and environmentally friendly practices
 
-  Focus areas: Basic programming, teamwork, communication, adaptability, willingness to learn.`,
+  Required skills: AutoCAD/Civil 3D, project management, structural analysis, surveying, construction regulations, teamwork.`,
+  },
+  {
+    value: "mechatronics-engineer",
+    label: "Mechatronics Engineer",
+    description: "Integration of mechanical, electrical, and software systems",
+    fullDescription: `A Mechatronics Engineer designs and develops automated systems and robotics. Key responsibilities include:
+
+    • Designing electro-mechanical systems and prototypes
+    • Developing embedded software for control systems
+    • Integrating sensors, actuators, and microcontrollers
+    • Testing and calibrating robotic systems
+    • Conducting simulations and performance analysis
+    • Working with interdisciplinary teams on automation projects
+    • Applying knowledge of control theory and system dynamics
+
+  Required skills: CAD software, embedded C/C++, Python/Matlab, PLC programming, robotics, electronics, systems integration.`,
+  },
+  {
+    value: "cybersecurity-analyst",
+    label: "Cybersecurity Analyst",
+    description: "Protecting systems and networks from cyber threats",
+    fullDescription: `A Cybersecurity Analyst is responsible for monitoring and defending IT systems. Key responsibilities include:
+
+    • Monitoring network traffic for suspicious activity
+    • Conducting vulnerability assessments and penetration tests
+    • Implementing security protocols and firewalls
+    • Responding to security incidents and breaches
+    • Ensuring compliance with security policies and regulations
+    • Training staff on security best practices
+    • Keeping up-to-date with evolving threats
+
+  Required skills: Network security, firewalls, SIEM tools, Python/Shell scripting, incident response, security frameworks (NIST, ISO).`,
+  },
+  {
+    value: "ml-engineer",
+    label: "Machine Learning Engineer",
+    description: "Building and deploying AI/ML models into production",
+    fullDescription: `A Machine Learning Engineer focuses on developing and scaling machine learning solutions. Key responsibilities include:
+
+    • Designing, training, and fine-tuning machine learning models
+    • Implementing data preprocessing and feature engineering pipelines
+    • Deploying ML models into production environments
+    • Optimizing models for performance and scalability
+    • Collaborating with data scientists and software engineers
+    • Monitoring models for drift and retraining as needed
+    • Documenting methodologies and results
+
+  Required skills: Python, TensorFlow/PyTorch, scikit-learn, SQL, cloud platforms (AWS/GCP/Azure), MLOps practices, data structures and algorithms.`,
+  },
+  {
+    value: "cloud-architect",
+    label: "Cloud Architect",
+    description: "Designing scalable and secure cloud solutions",
+    fullDescription: `A Cloud Architect designs and manages cloud infrastructure for enterprises. Key responsibilities include:
+
+    • Developing cloud architecture blueprints and strategies
+    • Designing secure, scalable, and cost-efficient solutions
+    • Migrating on-premise systems to the cloud
+    • Ensuring compliance with security and governance standards
+    • Collaborating with development and DevOps teams
+    • Evaluating emerging cloud technologies
+    • Providing technical leadership on cloud adoption
+
+  Required skills: AWS/Azure/GCP architecture, networking, security, Kubernetes, Terraform, cost optimization, stakeholder communication.`,
+  },
+  {
+    value: "structural-engineer",
+    label: "Structural Engineer",
+    description: "Design and analysis of safe, durable structures",
+    fullDescription: `A Structural Engineer specializes in ensuring that buildings and infrastructure can withstand loads and stresses. Key responsibilities include:
+
+    • Designing structural frameworks and components
+    • Performing load calculations and finite element analysis
+    • Preparing drawings, technical specifications, and reports
+    • Conducting site visits and inspections
+    • Ensuring compliance with building codes and safety regulations
+    • Collaborating with architects and construction teams
+    • Incorporating sustainability into structural design
+
+  Required skills: AutoCAD/Revit, SAP2000/ETABS, finite element analysis, construction materials knowledge, project management.`,
+  },
+  {
+    value: "electrical-engineer",
+    label: "Electrical Engineer",
+    description: "Design and maintenance of electrical systems",
+    fullDescription: `An Electrical Engineer works on electrical infrastructure and devices. Key responsibilities include:
+
+    • Designing power distribution, lighting, and control systems
+    • Developing electrical schematics and circuit layouts
+    • Performing calculations for load, efficiency, and safety
+    • Conducting inspections and troubleshooting electrical issues
+    • Ensuring compliance with electrical codes and standards
+    • Overseeing installation and commissioning of systems
+    • Collaborating on automation and renewable energy projects
+
+  Required skills: Circuit design, AutoCAD Electrical, PLCs, MATLAB/Simulink, renewable energy systems, safety standards (IEC/IEEE).`,
+  },
+  {
+    value: "ai-researcher",
+    label: "AI Researcher",
+    description: "Exploring cutting-edge artificial intelligence methods",
+    fullDescription: `An AI Researcher investigates and develops novel AI algorithms. Key responsibilities include:
+
+    • Conducting research in areas such as deep learning, reinforcement learning, and NLP
+    • Publishing findings in academic and industry journals
+    • Experimenting with large-scale datasets and models
+    • Collaborating with universities and research labs
+    • Developing prototypes for new AI applications
+    • Staying updated with the latest AI breakthroughs
+    • Mentoring junior researchers and interns
+
+  Required skills: Python, TensorFlow/PyTorch, mathematics (linear algebra, probability, optimization), research methodology, strong publication record.`,
+  },
+  {
+    value: "firmware-engineer",
+    label: "Firmware Engineer",
+    description: "Developing low-level software for embedded systems",
+    fullDescription: `A Firmware Engineer designs and implements firmware for embedded devices. Key responsibilities include:
+    • Writing efficient, low-level code in C/C++ for microcontrollers
+    • Developing device drivers and hardware abstraction layers
+    • Performing debugging and testing on embedded systems
+    • Collaborating with hardware engineers on system design
+    • Optimizing firmware for performance and power consumption
+    • Ensuring compliance with industry standards and protocols
+    • Documenting firmware architecture and changes
+  Required skills: Embedded C/C++, RTOS, microcontroller architectures (ARM, AVR), debugging tools (JTAG, oscilloscopes), version control (Git).`,
   },
 ];


### PR DESCRIPTION
This pull request adds support for multiple new job description categories and their corresponding mock data to both the backend and frontend. It expands the system to handle a broader range of technical and engineering roles, updates the job description category types, and improves the frontend job description selection options.

**Backend: Job Description Categories & Mock Data**
- Added new job description categories and their mock data for roles such as `software-engineer`, `civil-engineer`, `mechatronics-engineer`, `cybersecurity-analyst`, `ml-engineer`, `cloud-architect`, `structural-engineer`, `electrical-engineer`, `ai-researcher`, and `firmware-engineer`. Each category now includes a detailed mock job description file. [[1]](diffhunk://#diff-b43dfd2971d0d8a568221df67c61eac4fca4e6fb2e2375c0c3a83211a113d0dfR1-R27) [[2]](diffhunk://#diff-f2ab979cbaa1dd154c176921cead2407b001d3af493bc11d11fe402bf370fed7R1-R24) [[3]](diffhunk://#diff-63c219bceffe84798d01923419794e33e1f9d847901101b8115e87c521ad9747R1-R24) [[4]](diffhunk://#diff-6f348ebc2ca16c4193c692f41e43055507176f101ec343584db5088792a24f2aR1-R24) [[5]](diffhunk://#diff-ffa4ffbfd62fa2c0fc558c9b7fb0bc24ad66ebac788b3b0cb1fd2ef4af9b00edR1-R24) [[6]](diffhunk://#diff-5e24257984d206d77684a170de0af60a4b6e4875303bdf804d6da3c1fbe44df8R1-R24) [[7]](diffhunk://#diff-3822b8521803da37235c5bca690d39859fec5893268f44617649ded536cf7ef8R1-R24) [[8]](diffhunk://#diff-8cc6c15a504d7d12986a9bc877aef9e7923655d3b0c6c17b3fe9c1734e880bfaR1-R24) [[9]](diffhunk://#diff-77e1c9caf81f985622e5d757f63d0318bafd1d2d73adb405e86291f98eef0aa3R1-R24) [[10]](diffhunk://#diff-69eb67fc7b3a23f79c37e4727a01e8dcc5f047c0f2c952f6f55c0d8fa915d508R1-R22)

- Updated the `JobDescriptionCategory` type and the `jobDescriptionCategories` record in `index.ts` to include the new roles, ensuring that the backend can return the correct mock data for each category.

**Frontend: Job Description Selection**
- Updated the frontend `JobDescriptionCategory` type to match the expanded backend categories, allowing users to select from the new roles.

- Expanded `jobDescriptionOptions` with new entries for "Intern/Entry Level" and "Full-Stack Software Engineer", including detailed descriptions and expectations for each role.

**Default Selection Change**
- Changed the default selected job description in the interview analyzer component from "java-developer" to "intern" to better reflect entry-level usage.