### PR TITLE
Feat/timer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "prompt-recorder",
+  "name": "jobspeak-ai",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prompt-recorder",
+      "name": "jobspeak-ai",
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-select": "^2.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.6",

--- a/frontend/src/components/ActionButtons.tsx
+++ b/frontend/src/components/ActionButtons.tsx
@@ -7,6 +7,7 @@ interface ActionButtonsProps {
   mode: "record" | "upload";
   recording: boolean;
   hasVideo: boolean;
+  showQuestion: boolean;
   uploadedFile: File | null;
   isProcessing: boolean;
   isTranscribing: boolean;
@@ -22,6 +23,7 @@ export function ActionButtons({
   mode,
   recording,
   hasVideo,
+  showQuestion,
   uploadedFile,
   isProcessing,
   isTranscribing,
@@ -62,7 +64,7 @@ export function ActionButtons({
           </AlertDialogContent>
         </AlertDialog>
       ) : mode === "record" && !recording ? (
-        <Button onClick={onStartRecording} disabled={isProcessing || isTranscribing} className="cursor-pointer">
+          <Button onClick={onStartRecording} disabled={isProcessing || isTranscribing || !showQuestion} className="cursor-pointer">
           <VideoIcon className="w-4 h-4 mr-2" /> Start Recording
         </Button>
       ) : mode === "record" && recording ? (
@@ -73,7 +75,7 @@ export function ActionButtons({
 
       {/* Upload */}
       {mode === "upload" && !uploadedFile && (
-        <Button disabled={isProcessing || isTranscribing}>
+          <Button disabled={isProcessing || isTranscribing || !showQuestion}>
           <label className="flex items-center gap-2 cursor-pointer m-0">
             <Upload className="w-4 h-4 mr-2" />
             <span className="text-sm">Upload Video</span>

--- a/frontend/src/components/InterviewAnalyser.tsx
+++ b/frontend/src/components/InterviewAnalyser.tsx
@@ -164,7 +164,7 @@ export function InterviewAnalyser() {
                     <AlertDialogContent>
                       <AlertDialogHeader>
                         <AlertDialogTitle>Discard current video?</AlertDialogTitle>
-                        <AlertDialogDescription>Refreshing the question will remove the current recording or uploaded video. This cannot be undone.</AlertDialogDescription>
+                        <AlertDialogDescription>Refreshing the question will remove the current recording and uploaded video. This cannot be undone.</AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
                         <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>

--- a/frontend/src/components/InterviewAnalyser.tsx
+++ b/frontend/src/components/InterviewAnalyser.tsx
@@ -144,7 +144,7 @@ export function InterviewAnalyser() {
                     onClick={refreshQuestion}
                     className="hover:bg-primary/10 cursor-pointer"
                     aria-label="Refresh question"
-                    disabled={!showQuestion}
+                    disabled={!showQuestion || recording || isTranscribing || isProcessing}
                   >
                     <RefreshCw className="h-4 w-4" />
                   </Button>

--- a/frontend/src/components/InterviewAnalyser.tsx
+++ b/frontend/src/components/InterviewAnalyser.tsx
@@ -16,6 +16,8 @@ import Nav from './Nav';
 import InterviewRecorder from './InterviewRecorder';
 import TargetRole from './TargetRole';
 import { Alert, AlertTitle, AlertDescription } from './ui/alert';
+import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogTitle, AlertDialogDescription, AlertDialogCancel, AlertDialogAction } from './ui/alert-dialog';
+import { AlertDialogHeader, AlertDialogFooter } from './ui/alert-dialog';
 
 export function InterviewAnalyser() {
   const [selectedJobDescription, setSelectedJobDescription] = useState<JobDescriptionCategory>('general');
@@ -64,14 +66,22 @@ export function InterviewAnalyser() {
     handleFileUpload,
     switchMode,
     clearUploadedFile,
+    resetRecorder,
   } = useRecorder(question, selectedJobDescription, customJobDescription);
 
-  const refreshQuestion = useCallback(() => {
+  const [showConfirmRefresh, setShowConfirmRefresh] = useState(false);
+
+  const refreshQuestionAndRecorder = useCallback(() => {
     setQuestion(getRandomQuestion());
     setShowQuestion(false);
     thinkingTimer.reset();
     responseTimer.reset();
-  }, [thinkingTimer, responseTimer]);
+    resetRecorder();
+  }, [thinkingTimer, responseTimer, resetRecorder]);
+
+  const handleRefreshClick = () => {
+    setShowConfirmRefresh(true);
+  };
 
   useEffect(() => {
     if (!question) {
@@ -138,21 +148,38 @@ export function InterviewAnalyser() {
                   >
                     {showQuestion ? <Eye className="h-5 w-5" /> : <EyeOff className="h-5 w-5" />}
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={refreshQuestion}
-                    className="hover:bg-primary/10 cursor-pointer"
-                    aria-label="Refresh question"
-                    disabled={!showQuestion || recording || isTranscribing || isProcessing}
-                  >
-                    <RefreshCw className="h-4 w-4" />
-                  </Button>
+                  <AlertDialog open={showConfirmRefresh} onOpenChange={setShowConfirmRefresh}>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleRefreshClick}
+                        className="hover:bg-primary/10 cursor-pointer"
+                        aria-label="Refresh question"
+                        disabled={!showQuestion || recording || isTranscribing || isProcessing}
+                      >
+                        <RefreshCw className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Discard current video?</AlertDialogTitle>
+                        <AlertDialogDescription>Refreshing the question will remove the current recording or uploaded video. This cannot be undone.</AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => {
+                          refreshQuestionAndRecorder();
+                          setShowConfirmRefresh(false);
+                        }} className="cursor-pointer">Discard & Refresh</AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
               </div>
               <QuestionPrompt question={showQuestion ? question : null} />
-              {/* Thinking Timer */}
-              {showQuestion && thinkingTimer.active && !recording && (
+              {/* Thinking Timer (only for record mode) */}
+              {mode === "record" && showQuestion && thinkingTimer.active && !recording && (
                 <div className="mt-4">
                   <Timer
                     duration={thinkingTime}
@@ -192,9 +219,10 @@ export function InterviewAnalyser() {
               onClearUploadedFile={clearUploadedFile}
               onTranscribe={transcribeRecording}
               onSave={saveRecording}
+              showQuestion={showQuestion}
             />
-            {/* Response Timer */}
-            {responseTimer.active && recording && (
+            {/* Response Timer (only for record mode) */}
+            {mode === "record" && responseTimer.active && recording && (
               <div className="mt-4">
                 <Timer
                   duration={responseTime}

--- a/frontend/src/components/InterviewAnalyser.tsx
+++ b/frontend/src/components/InterviewAnalyser.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useTimer } from '@/hooks/useTimer';
+import { Timer } from './Timer';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { AlertCircle, RefreshCw } from 'lucide-react';
@@ -21,6 +23,25 @@ export function InterviewAnalyser() {
 
   const [question, setQuestion] = useState<Question | null>(null);
   const [showQuestion, setShowQuestion] = useState(false);
+  const [thinkingTime] = useState(() => Number(window.localStorage.getItem('thinkingTime')) || 60);
+  const [responseTime] = useState(() => Number(window.localStorage.getItem('responseTime')) || 120);
+
+  const thinkingTimer = useTimer({
+    duration: thinkingTime,
+    autoStart: false,
+    onComplete: () => {
+      startRecording();
+      responseTimer.start();
+    },
+  });
+  const responseTimer = useTimer({
+    duration: responseTime,
+    autoStart: false,
+    onComplete: () => {
+      stopRecording();
+    },
+  });
+
   const {
     recording,
     recordedChunks,
@@ -48,14 +69,46 @@ export function InterviewAnalyser() {
   const refreshQuestion = useCallback(() => {
     setQuestion(getRandomQuestion());
     setShowQuestion(false);
-  }, []);
+    thinkingTimer.reset();
+    responseTimer.reset();
+  }, [thinkingTimer, responseTimer]);
 
   useEffect(() => {
-    refreshQuestion();
-  }, [refreshQuestion]);
+    if (!question) {
+      setQuestion(getRandomQuestion());
+    }
+  }, [question]);
+
+  useEffect(() => {
+    if (showQuestion && !recording) {
+      thinkingTimer.start();
+    } else if (!showQuestion) {
+      thinkingTimer.stop();
+      thinkingTimer.reset();
+      responseTimer.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showQuestion]);
+
+  // Manual start recording (skips thinking timer)
+  const handleManualStartRecording = () => {
+    if (thinkingTimer.active) {
+      thinkingTimer.stop();
+      thinkingTimer.reset();
+    }
+    setShowQuestion(true);
+    startRecording();
+    responseTimer.start();
+  };
+
+  // Manual stop recording
+  const handleManualStopRecording = () => {
+    responseTimer.stop();
+    stopRecording();
+  };
 
   return (
-  <div className="flex flex-col h-screen bg-background">
+    <div className="flex flex-col h-screen bg-background">
       {/* Navbar */}
       <div className="fixed top-0 left-0 right-0 z-50">
         <Nav />
@@ -76,26 +129,37 @@ export function InterviewAnalyser() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => setShowQuestion((prev) => !prev)}
+                    onClick={() => {
+                      if (!showQuestion && question) setShowQuestion(true);
+                    }}
                     className="hover:bg-primary/10 cursor-pointer"
                     aria-label={showQuestion ? "Hide question" : "Show question"}
                     disabled={showQuestion}
                   >
                     {showQuestion ? <Eye className="h-5 w-5" /> : <EyeOff className="h-5 w-5" />}
                   </Button>
-                    <Button
+                  <Button
                     variant="ghost"
                     size="sm"
                     onClick={refreshQuestion}
                     className="hover:bg-primary/10 cursor-pointer"
                     aria-label="Refresh question"
                     disabled={!showQuestion}
-                    >
+                  >
                     <RefreshCw className="h-4 w-4" />
-                    </Button>
+                  </Button>
                 </div>
               </div>
               <QuestionPrompt question={showQuestion ? question : null} />
+              {/* Thinking Timer */}
+              {showQuestion && thinkingTimer.active && !recording && (
+                <div className="mt-4">
+                  <Timer
+                    duration={thinkingTime}
+                    running={thinkingTimer.active}
+                  />
+                </div>
+              )}
             </div>
 
             <Separator />
@@ -122,13 +186,22 @@ export function InterviewAnalyser() {
               isProcessing={isProcessing}
               isTranscribing={isTranscribing}
               onSwitchMode={switchMode}
-              onStartRecording={startRecording}
-              onStopRecording={stopRecording}
+              onStartRecording={handleManualStartRecording}
+              onStopRecording={handleManualStopRecording}
               onFileUpload={handleFileUpload}
               onClearUploadedFile={clearUploadedFile}
               onTranscribe={transcribeRecording}
               onSave={saveRecording}
             />
+            {/* Response Timer */}
+            {responseTimer.active && recording && (
+              <div className="mt-4">
+                <Timer
+                  duration={responseTime}
+                  running={responseTimer.active}
+                />
+              </div>
+            )}
 
             {/* Error Message */}
             {error && (

--- a/frontend/src/components/InterviewRecorder.tsx
+++ b/frontend/src/components/InterviewRecorder.tsx
@@ -10,6 +10,7 @@ interface InterviewRecorderProps {
   recording: boolean;
   isProcessing: boolean;
   isTranscribing: boolean;
+  showQuestion: boolean;
   onSwitchMode: (mode: "record" | "upload") => void;
   onStartRecording: () => void;
   onStopRecording: () => void;
@@ -22,13 +23,20 @@ interface InterviewRecorderProps {
 export default function InterviewRecorder(props: InterviewRecorderProps) {
   const hasVideo = (props.mode === "record" && props.recordedChunks.length > 0 && !props.recording) || (props.mode === "upload" && !!props.uploadedFile);
 
+  // Prevent switching modes if question is visible
+  const disableModeSwitch = props.showQuestion;
+
   return (
     <div className="space-y-4">
       {/* Mode Tabs */}
-      <Tabs value={props.mode} onValueChange={value => props.onSwitchMode(value as "record" | "upload")}>
+      <Tabs value={props.mode} onValueChange={value => {
+        if (!disableModeSwitch) {
+          props.onSwitchMode(value as "record" | "upload");
+        }
+      }}>
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="record" className="cursor-pointer">Record</TabsTrigger>
-          <TabsTrigger value="upload" className="cursor-pointer">Upload</TabsTrigger>
+          <TabsTrigger value="record" className="cursor-pointer" disabled={disableModeSwitch}>Record</TabsTrigger>
+          <TabsTrigger value="upload" className="cursor-pointer" disabled={disableModeSwitch}>Upload</TabsTrigger>
         </TabsList>
       </Tabs>
 
@@ -46,6 +54,7 @@ export default function InterviewRecorder(props: InterviewRecorderProps) {
         mode={props.mode}
         recording={props.recording}
         hasVideo={hasVideo}
+        showQuestion={props.showQuestion}
         uploadedFile={props.uploadedFile}
         isProcessing={props.isProcessing}
         isTranscribing={props.isTranscribing}

--- a/frontend/src/components/InterviewRecorder.tsx
+++ b/frontend/src/components/InterviewRecorder.tsx
@@ -29,7 +29,7 @@ export default function InterviewRecorder(props: InterviewRecorderProps) {
   return (
     <div className="space-y-4">
       {/* Mode Tabs */}
-      <Tabs value={props.mode} onValueChange={value => {
+      <Tabs className="mb-3" value={props.mode} onValueChange={value => {
         if (!disableModeSwitch) {
           props.onSwitchMode(value as "record" | "upload");
         }

--- a/frontend/src/components/JobDescriptionSelector/JobDescriptionSelector.tsx
+++ b/frontend/src/components/JobDescriptionSelector/JobDescriptionSelector.tsx
@@ -41,7 +41,7 @@ export const JobDescriptionSelector: React.FC<JobDescriptionSelectorProps> = ({
 
   return (
     <div>
-      <div className="items-center mb-4">
+      <div className="items-center mb-3">
         <Tabs defaultValue="select" onValueChange={handleModeToggle}>
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="select" className="cursor-pointer">Select Job</TabsTrigger>

--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -1,8 +1,19 @@
+import { useState } from "react";
 import { Mic, Video, Text } from "lucide-react";
 import Footer from "./Footer";
 import AnimatedBackground from "./AnimatedBackground";
+import { TimelineModal } from "./TimelineModal";
 
 export default function Landing() {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleConfirm = (thinking: number, response: number) => {
+    setModalOpen(false);
+    window.localStorage.setItem("thinkingTime", thinking.toString());
+    window.localStorage.setItem("responseTime", response.toString());
+    window.location.href = "/interview-analyser";
+  };
+
   return (
     <div className="min-h-screen flex flex-col relative overflow-hidden text-gray-100">
       <div>
@@ -19,12 +30,12 @@ export default function Landing() {
           <p className="text-gray-300 text-xl md:text-2xl mb-12">
             Personalised AI-powered feedback on your behavioral interview responses
           </p>
-          <a
-            href="/interview-analyser"
+          <button
+            onClick={() => setModalOpen(true)}
             className="bg-indigo-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-indigo-600 transition cursor-pointer"
           >
-            Get Started
-          </a>
+            Start Interviewing
+          </button>
         </div>
       </header>
 
@@ -71,6 +82,12 @@ export default function Landing() {
       </main>
 
       <Footer />
+      {/* Timeline Modal */}
+      <TimelineModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onConfirm={handleConfirm}
+      />
     </div>
   );
 }

--- a/frontend/src/components/TimelineModal.tsx
+++ b/frontend/src/components/TimelineModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+
+interface TimelineModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (thinkingTime: number, responseTime: number) => void;
+}
+
+export const TimelineModal: React.FC<TimelineModalProps> = ({ open, onClose, onConfirm }) => {
+  const [thinkingTime, setThinkingTime] = useState(60); // seconds
+  const [responseTime, setResponseTime] = useState(120); // seconds
+
+  return (
+    <Dialog open={open} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="max-w-md w-full">
+        <DialogHeader>
+          <DialogTitle>Set Interview Timers</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          {/* Thinking Time Selector */}
+          <div>
+            <label className="block text-sm font-medium mb-2">Thinking Time Limit</label>
+            <input
+              type="range"
+              min={30}
+              max={180}
+              value={thinkingTime}
+              onChange={e => setThinkingTime(Number(e.target.value))}
+              className="w-full accent-primary cursor-pointer"
+            />
+            <div className="flex justify-between text-xs mt-1 text-muted-foreground">
+              <span>30s</span>
+              <span>{Math.floor(thinkingTime / 60)}:{(thinkingTime % 60).toString().padStart(2, "0")}</span>
+              <span>3m</span>
+            </div>
+          </div>
+          {/* Response Time Selector */}
+          <div>
+            <label className="block text-sm font-medium mb-2">Response Time Limit</label>
+            <input
+              type="range"
+              min={60}
+              max={300}
+              value={responseTime}
+              onChange={e => setResponseTime(Number(e.target.value))}
+              className="w-full accent-primary cursor-pointer"
+            />
+            <div className="flex justify-between text-xs mt-1 text-muted-foreground">
+              <span>1m</span>
+              <span>{Math.floor(responseTime / 60)}:{(responseTime % 60).toString().padStart(2, "0")}</span>
+              <span>5m</span>
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 mt-8">
+          <Button variant="outline" onClick={onClose} className="cursor-pointer">Cancel</Button>
+          <Button
+            onClick={() => onConfirm(thinkingTime, responseTime)}
+            className="cursor-pointer"
+          >
+            Confirm
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Progress } from "./ui/progress";
+
+interface TimerProps {
+  duration: number; // in seconds
+  onComplete?: () => void;
+  running?: boolean;
+  onStart?: () => void;
+}
+
+export const Timer: React.FC<TimerProps> = ({
+  duration,
+  onComplete,
+  running = true,
+  onStart,
+}) => {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (running) {
+      if (onStart) onStart();
+      setElapsedMs(0);
+      intervalRef.current = setInterval(() => {
+        setElapsedMs((prev) => {
+          const next = prev + 20; // update every 20ms for smoother progress
+          if (next >= duration * 1000) {
+            clearInterval(intervalRef.current!);
+            if (onComplete) onComplete();
+            return duration * 1000;
+          }
+          return next;
+        });
+      }, 20);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [onComplete, onStart, running, duration]);
+
+  useEffect(() => {
+    setElapsedMs(0);
+  }, [duration]);
+
+  const secondsLeft = Math.max(0, duration - Math.floor(elapsedMs / 1000));
+
+  const formatTime = (secs: number) => {
+    const m = Math.floor(secs / 60)
+      .toString()
+      .padStart(2, "0");
+    const s = (secs % 60).toString().padStart(2, "0");
+    return `${m}:${s}`;
+  };
+
+  const percent = Math.max(
+    0,
+    100 * (1 - elapsedMs / (duration * 1000))
+  );
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full">
+      <Progress
+        value={percent}
+        className="w-full max-w-xs h-1 mb-2"
+      />
+      <span className="text-sm font-mono text-muted-foreground select-none tracking-wide">
+        {formatTime(secondsLeft)}
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/hooks/useRecorder.ts
+++ b/frontend/src/hooks/useRecorder.ts
@@ -368,13 +368,23 @@ export const useRecorder = (
     }
   };
 
-  const cancelAnalysis = () => {
-    analysisAbortControllerRef.current?.abort();
-    transcriptionAbortControllerRef.current?.abort();
-    setIsProcessing(false);
-    setIsTranscribing(false);
-    setError("Operation cancelled");
+  const resetRecorder = () => {
+    resetState();
+    setRecordedChunks([]);
+    setUploadedFile(null);
+    setTranscription("");
+    setShowTranscription(false);
+    setStream(null);
+    setRecording(false);
   };
+
+  // const cancelAnalysis = () => {
+  //   analysisAbortControllerRef.current?.abort();
+  //   transcriptionAbortControllerRef.current?.abort();
+  //   setIsProcessing(false);
+  //   setIsTranscribing(false);
+  //   setError("Operation cancelled");
+  // };
 
   return {
     recording,
@@ -399,5 +409,6 @@ export const useRecorder = (
     handleFileUpload,
     switchMode,
     clearUploadedFile,
+    resetRecorder,
   };
 };

--- a/frontend/src/hooks/useTimer.ts
+++ b/frontend/src/hooks/useTimer.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseTimerOptions {
+  duration: number; // seconds
+  autoStart?: boolean;
+  onComplete?: () => void;
+  onStart?: () => void;
+}
+
+export function useTimer({ duration, autoStart = false, onComplete, onStart }: UseTimerOptions) {
+  const [active, setActive] = useState(autoStart);
+  const [secondsLeft, setSecondsLeft] = useState(duration);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Start timer
+  const start = useCallback(() => {
+    setActive(true);
+    if (onStart) onStart();
+  }, [onStart]);
+
+  // Stop timer
+  const stop = useCallback(() => {
+    setActive(false);
+    setSecondsLeft(duration);
+    if (intervalRef.current) clearInterval(intervalRef.current);
+  }, [duration]);
+
+  // Reset timer
+  const reset = useCallback(() => {
+    setSecondsLeft(duration);
+    setActive(false);
+    if (intervalRef.current) clearInterval(intervalRef.current);
+  }, [duration]);
+
+  useEffect(() => {
+    setSecondsLeft(duration);
+  }, [duration]);
+
+  useEffect(() => {
+    if (!active) return;
+    intervalRef.current = setInterval(() => {
+      setSecondsLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(intervalRef.current!);
+          setActive(false);
+          if (onComplete) onComplete();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [active, onComplete]);
+
+  return {
+    secondsLeft,
+    percent: Math.max(0, Math.round((secondsLeft / duration) * 100)),
+    active,
+    start,
+    stop,
+    reset,
+  };
+}


### PR DESCRIPTION
This pull request introduces a major feature to the interview analysis workflow: customizable timers for both "thinking" and "response" phases, enhancing the user experience and adding structure to interview practice. It also refines the UI to ensure users cannot switch modes or upload/record videos until the question is revealed, and adds confirmation dialogs to prevent accidental data loss. The onboarding flow is improved with a modal for timer setup on the landing page.

**Timer Functionality & Interview Flow**

* Added a `TimelineModal` component and integration on the landing page, allowing users to set custom thinking and response time limits before starting their interview session. These values are stored in `localStorage` and used throughout the app. [[1]](diffhunk://#diff-283d1b2acdddf92de12dcbfd435ba64b6600e2a9994c728a18c4e38e034f1c6cR1-R69) [[2]](diffhunk://#diff-4e99a2aca76066bdfbc8b55c3790bb3b33981d5f3e9c702091056503a5f5b547R1-R16) [[3]](diffhunk://#diff-4e99a2aca76066bdfbc8b55c3790bb3b33981d5f3e9c702091056503a5f5b547L22-R38) [[4]](diffhunk://#diff-4e99a2aca76066bdfbc8b55c3790bb3b33981d5f3e9c702091056503a5f5b547R85-R90)
* Implemented a reusable `Timer` component to visually show countdowns for thinking and response phases. Timers are triggered appropriately in the interview flow, and recording automatically starts/stops based on timer completion. [[1]](diffhunk://#diff-cf490b967d1d3613a3a71ab0a6ffd2004a4842125d3eba2fbf7ceb4b8f563424R1-R71) [[2]](diffhunk://#diff-c513c860b43b732e285b1df6f9abc1b484c54e87f8e031b32b1c6a40f692bacfR2-R3) [[3]](diffhunk://#diff-c513c860b43b732e285b1df6f9abc1b484c54e87f8e031b32b1c6a40f692bacfR69-R118) [[4]](diffhunk://#diff-c513c860b43b732e285b1df6f9abc1b484c54e87f8e031b32b1c6a40f692bacfL79-R189) [[5]](diffhunk://#diff-c513c860b43b732e285b1df6f9abc1b484c54e87f8e031b32b1c6a40f692bacfL125-R232)

**User Interaction Safeguards**

* Users cannot switch between "record" and "upload" modes, nor start recording/uploading, until the question is revealed (`showQuestion`). UI buttons are disabled accordingly, and the mode switch tabs are locked when the question is visible. [[1]](diffhunk://#diff-86ae091edcd9d510b741760c247b155fdfbe158f19b0d229186c9a2080997555R10) [[2]](diffhunk://#diff-86ae091edcd9d510b741760c247b155fdfbe158f19b0d229186c9a2080997555R26) [[3]](diffhunk://#diff-86ae091edcd9d510b741760c247b155fdfbe158f19b0d229186c9a2080997555L65-R67) [[4]](diffhunk://#diff-86ae091edcd9d510b741760c247b155fdfbe158f19b0d229186c9a2080997555L76-R78) [[5]](diffhunk://#diff-a931e425b5a3c2ebbf4fd2a20990cf7e1a9b121ff88cc7095fc870cbc268fee0R13) [[6]](diffhunk://#diff-a931e425b5a3c2ebbf4fd2a20990cf7e1a9b121ff88cc7095fc870cbc268fee0R26-R39) [[7]](diffhunk://#diff-a931e425b5a3c2ebbf4fd2a20990cf7e1a9b121ff88cc7095fc870cbc268fee0R57)

**Confirmation Dialogs & Error Prevention**

* Added an alert dialog that prompts users to confirm before refreshing the question, warning that it will discard any current recording or uploaded video. This helps prevent accidental loss of work. [[1]](diffhunk://#diff-c513c860b43b732e285b1df6f9abc1b484c54e87f8e031b32b1c6a40f692bacfR69-R118) [[2]](diffhunk://#diff-c513c860b43b732e285b1df6f9abc1b484c54e87f8e031b32b1c6a40f692bacfL79-R189)

**Dependency and Package Updates**

* Updated project name in `package.json` and `package-lock.json` to `jobspeak-ai` and added the `@radix-ui/react-dialog` dependency for modal support. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL2-R13) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R15)

**Minor UI Tweaks**

* Adjusted spacing in the job description selector for improved visual consistency.

These changes collectively make the interview simulation more realistic, user-friendly, and robust against accidental actions, while introducing timer-driven structure to the practice workflow.